### PR TITLE
Build index of seq_ids for each database

### DIFF
--- a/lib/sequenceserver/sequence.rb
+++ b/lib/sequenceserver/sequence.rb
@@ -59,7 +59,7 @@ module SequenceServer
 
         # Output of the command will be five columns TSV.
         command = "blastdbcmd -outfmt '%g	%i	%a	%t	%s'" \
-          " -db '#{database_names}' -entry '#{accessions}'"
+                  " -db '#{database_names}' -entry '#{accessions}'"
 
         logger.debug("Executing: #{command}")
 
@@ -109,6 +109,11 @@ module SequenceServer
     # Returns FASTA sequence id.
     def id
       (gi ? ['gi', gi, seqid] : [seqid]).join('|')
+    end
+
+    # Returns an array of all database objects where the accession is found.
+    def which_blastdb
+      Database.select {|db| db.include?(accession)}
     end
 
     # Returns length of the sequence.


### PR DESCRIPTION
Each Database object now contains a set of seq_ids contained within it.
This allows us to determine whether a Database contains a particular
sequence id or not.

e.g., `database.include?(accession) => true/false`

Another use of this feature is that it provides reverse lookup i.e.,
find which database contains this particular sequence. However, in many
cases a single sequence id can be present in multiple databases at a
time. We return all of the values and not just the first value.

e.g., `sequence.which_blastdb => [<Database object>, ..]`

Signed-off-by: Vivek Rai vivekraiiitkgp@gmail.com
